### PR TITLE
Reedit wording for takecredits

### DIFF
--- a/chat-plugins/credits.js
+++ b/chat-plugins/credits.js
@@ -148,7 +148,7 @@ exports.commands = {
 		writeMoney(targetUser, -amount);
 		this.sendReply("You removed " + amount + ((amount === 1) ? " credit " : " credits ") + " from " + Tools.escapeHTML(targetUser));
 		logTransaction(user.name + " has taken " + amount + ((amount === 1) ? " credit " : " credits ") + " from " + targetUser);
-		Rooms.get('marketplace').add('|raw|' + user.name + " has given " + amount + ((amount === 1) ? " credit " : " credits ") + " to " + targetUser);
+		Rooms.get('marketplace').add('|raw|' + user.name + " has taken " + amount + ((amount === 1) ? " credit " : " credits ") + " from " + targetUser);
 	},
 
 	transfercredits: function (target, room, user) {


### PR DESCRIPTION
When I was taking away credits from a certain user since they were unicoded, it said this when I did the command /takecredits alliancecrimson,11

You removed 11 credits from alliancecrimson
Mighty Sciz has given 11 credits to alliancecrimson

So, I made this PR so then the wording for takecredits can make a bit more sense, because that the users were confused into thinking that I was giving him more credits.
